### PR TITLE
Don't encode tmpdir path during ReceiveSIP

### DIFF
--- a/ESSArch_PP/workflow/tasks.py
+++ b/ESSArch_PP/workflow/tasks.py
@@ -129,11 +129,11 @@ class ReceiveSIP(DBTask):
             if container_type == '.tar':
                 with tarfile.open(container) as tar:
                     root_member_name = tar.getnames()[0]
-                    tar.extractall(tmpdir.encode('utf-8'))
+                    tar.extractall(tmpdir)
             elif container_type == '.zip':
                 with zipfile.ZipFile(container) as zipf:
                     root_member_name = zipf.namelist()[0]
-                    zipf.extractall(tmpdir.encode('utf-8'))
+                    zipf.extractall(tmpdir)
             else:
                 raise ValueError(u'Invalid container type: {}'.format(container))
 


### PR DESCRIPTION
The encoding is from an old "fix" of a bug that is not reproducible in
either Python 2 or 3. We revert this until the problem comes back and
hopefully we can write a test for it then.