### PR TITLE
Wrap access route in transaction

### DIFF
--- a/ESSArch_PP/ip/views.py
+++ b/ESSArch_PP/ip/views.py
@@ -869,6 +869,7 @@ class InformationPackageViewSet(InformationPackageViewSetCore):
         main_step.run()
         return Response({'detail': 'Preserving %s...' % ip.object_identifier_value})
 
+    @transaction.atomic
     @detail_route(methods=['post'])
     def access(self, request, pk=None):
         aip = self.get_object()


### PR DESCRIPTION
This ensures that the created task is deleted if, for example, the connection to the message broker is lost