### PR TITLE
Fix bug when viewing tag not assigned to group

### DIFF
--- a/ESSArch_PP/tags/search.py
+++ b/ESSArch_PP/tags/search.py
@@ -273,9 +273,10 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
         obj = get_object_or_404(tag_version, pk=id)
         user_archives = get_objects_for_user(self.request.user, tag_version.filter(elastic_index='archive'), []).values_list('pk', flat=True)
 
-        if obj.get_root() is not None and obj.get_root().pk not in user_archives:
-            obj_ctype = ContentType.objects.get_for_model(obj)
-            in_any_groups = GroupGenericObjects.objects.filter(object_id=str(obj.pk), content_type=obj_ctype).exists()
+        root = obj.get_root()
+        if root is not None and root.pk not in user_archives:
+            obj_ctype = ContentType.objects.get_for_model(root)
+            in_any_groups = GroupGenericObjects.objects.filter(object_id=str(root.pk), content_type=obj_ctype).exists()
 
             if in_any_groups:
                 raise exceptions.NotFound

--- a/ESSArch_PP/tags/search.py
+++ b/ESSArch_PP/tags/search.py
@@ -272,8 +272,13 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
 
         obj = get_object_or_404(tag_version, pk=id)
         user_archives = get_objects_for_user(self.request.user, tag_version.filter(elastic_index='archive'), []).values_list('pk', flat=True)
+
         if obj.get_root() is not None and obj.get_root().pk not in user_archives:
-            raise exceptions.NotFound
+            obj_ctype = ContentType.objects.get_for_model(obj)
+            in_any_groups = GroupGenericObjects.objects.filter(object_id=str(obj.pk), content_type=obj_ctype).exists()
+
+            if in_any_groups:
+                raise exceptions.NotFound
         return obj
 
     def verify_sort_field(self, field, direction='asc'):


### PR DESCRIPTION
If the tag is not part of any of the user's archives, then we check if its root is assigned to any group. If not, then we allow the user to see the tag, otherwise we hide it from the user