### PR TITLE
Use built-in scandir

### DIFF
--- a/ESSArch_PP/workflow/tasks.py
+++ b/ESSArch_PP/workflow/tasks.py
@@ -50,7 +50,7 @@ from django.db.models import F
 from django.utils import timezone
 from groups_manager.utils import get_permission_name
 from guardian.shortcuts import assign_perm
-from scandir import walk
+from os import walk
 from six.moves import urllib
 
 # noinspection PyUnresolvedReferences


### PR DESCRIPTION
`scandir` is built-in to Python since 3.5: https://docs.python.org/3/whatsnew/3.5.html#pep-471-os-scandir-function-a-better-and-faster-directory-iterator