### PR TITLE
Use built-in mock

### DIFF
--- a/ESSArch_PP/ip/tests/test_ips.py
+++ b/ESSArch_PP/ip/tests/test_ips.py
@@ -32,7 +32,7 @@ from django.urls import reverse
 
 from groups_manager.models import GroupType
 
-import mock
+import unittest.mock
 
 from rest_framework import status
 from rest_framework.response import Response

--- a/ESSArch_PP/ip/tests/test_ips.py
+++ b/ESSArch_PP/ip/tests/test_ips.py
@@ -32,7 +32,7 @@ from django.urls import reverse
 
 from groups_manager.models import GroupType
 
-import unittest.mock
+from unittest import mock
 
 from rest_framework import status
 from rest_framework.response import Response

--- a/ESSArch_PP/workflow/tests/test_real_tasks.py
+++ b/ESSArch_PP/workflow/tests/test_real_tasks.py
@@ -37,7 +37,7 @@ from django.contrib.auth.models import User
 from django.test import tag, TransactionTestCase, override_settings
 from django.utils.timezone import localtime
 
-import unittest.mock
+from unittest import mock
 
 from ESSArch_Core.configuration.models import (
     ArchivePolicy, Path,

--- a/ESSArch_PP/workflow/tests/test_real_tasks.py
+++ b/ESSArch_PP/workflow/tests/test_real_tasks.py
@@ -37,7 +37,7 @@ from django.contrib.auth.models import User
 from django.test import tag, TransactionTestCase, override_settings
 from django.utils.timezone import localtime
 
-import mock
+import unittest.mock
 
 from ESSArch_Core.configuration.models import (
     ArchivePolicy, Path,


### PR DESCRIPTION
`mock` is built-in to Python since 3.3: https://docs.python.org/3/whatsnew/3.3.html