### PR TITLE
Use isNaN instead of Number.isNaN

### DIFF
--- a/ESSArch_PP/frontend/static/frontend/scripts/controllers/SearchCtrl.js
+++ b/ESSArch_PP/frontend/static/frontend/scripts/controllers/SearchCtrl.js
@@ -162,7 +162,7 @@ angular.module('essarch.controllers').controller('SearchCtrl', function(Search, 
             var pagination = tableState.pagination;
             var start = pagination.start || 0;     // This is NOT the page number, but the index of item in the list that you want to use to display the table.
             var number = pagination.number;  // Number of entries showed per page.
-            var pageNumber = Number.isNaN(start / number)? 1 : start  /number + 1; // Prevents initial 404 response where pagenumber os NaN in request
+            var pageNumber = isNaN(start / number)? 1 : start  /number + 1; // Prevents initial 404 response where pagenumber os NaN in request
             vm.formatFilters();
             if(vm.filterObject.extension == "" || vm.filterObject.extension == null || vm.filterObject.extension == {}) {
                 delete vm.filterObject.extension;


### PR DESCRIPTION
Number.isNaN is not supported by Internet explorer but isNaN is.

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#Browser_compatibility
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#Browser_compatibility