### PR TITLE
Remove Python 2/3 compatibility imports

### DIFF
--- a/ESSArch_PP/config/__init__.py
+++ b/ESSArch_PP/config/__init__.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import, unicode_literals
-
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app  # noqa

--- a/ESSArch_PP/config/celery.py
+++ b/ESSArch_PP/config/celery.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import
-
 import os
 
 from celery import Celery

--- a/ESSArch_PP/tags/search.py
+++ b/ESSArch_PP/tags/search.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import copy
 import csv
 import datetime

--- a/ESSArch_PP/workflow/tasks.py
+++ b/ESSArch_PP/workflow/tasks.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import
-
 import copy
 import datetime
 import errno


### PR DESCRIPTION
We have upgraded to Python 3, we no longer require tools that makes the migration easier