### PR TITLE
Replace super(ClassName, self) with super()

### DIFF
--- a/ESSArch_PP/ip/serializers.py
+++ b/ESSArch_PP/ip/serializers.py
@@ -240,7 +240,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 
     def save(self, **kwargs):
         kwargs["responsible"] = self.fields["responsible"].get_default()
-        return super(OrderSerializer, self).save(**kwargs)
+        return super().save(**kwargs)
 
     class Meta:
         model = Order

--- a/ESSArch_PP/ip/views.py
+++ b/ESSArch_PP/ip/views.py
@@ -748,7 +748,7 @@ class InformationPackageViewSet(InformationPackageViewSetCore):
         return InformationPackageDetailSerializer
 
     def get_serializer_context(self):
-        context = super(InformationPackageViewSet, self).get_serializer_context()
+        context = super().get_serializer_context()
         context['view'] = self
 
         checker = ObjectPermissionChecker(self.request.user)
@@ -836,7 +836,7 @@ class InformationPackageViewSet(InformationPackageViewSetCore):
 
                 step.run()
 
-        return super(InformationPackageViewSet, self).destroy(request, pk=pk)
+        return super().destroy(request, pk=pk)
 
     @detail_route(methods=['post'])
     def receive(self, request, pk=None):

--- a/ESSArch_PP/profiles/views.py
+++ b/ESSArch_PP/profiles/views.py
@@ -60,7 +60,7 @@ class SubmissionAgreementViewSet(SAViewSetCore):
             detail = 'Method "{method}" is not allowed on published SAs'.format(method=request.method)
             raise exceptions.MethodNotAllowed(method=request.method, detail=detail)
 
-        return super(SubmissionAgreementViewSet, self).update(request, *args, **kwargs)
+        return super().update(request, *args, **kwargs)
 
     @detail_route(methods=['post'])
     def publish(self, request, pk=None):

--- a/ESSArch_PP/storage/admin.py
+++ b/ESSArch_PP/storage/admin.py
@@ -52,7 +52,7 @@ class StorageTargetInline(NestedStackedInline):
     verbose_name_plural = ''
 
     def get_formset(self, request, obj=None, **kwargs):
-        formset = super(StorageTargetInline, self).get_formset(request, obj, **kwargs)
+        formset = super().get_formset(request, obj, **kwargs)
         form = formset.form
         form.base_fields['storage_target'].widget.can_add_related = False
         form.base_fields['storage_target'].widget.can_change_related = False

--- a/ESSArch_PP/tags/search.py
+++ b/ESSArch_PP/tags/search.py
@@ -107,7 +107,7 @@ class ComponentSearch(FacetedSearch):
             if self.start_date > self.end_date:
                 raise exceptions.ParseError('start_date cannot be set to date after end_date')
 
-        super(ComponentSearch, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def search(self):
         """
@@ -121,7 +121,7 @@ class ComponentSearch(FacetedSearch):
         organization_archives = get_objects_for_user(self.user, TagVersion.objects.filter(elastic_index='archive'), [])
         organization_archives = list(organization_archives.values_list('pk', flat=True))
 
-        s = super(ComponentSearch, self).search()
+        s = super().search()
         s = s.source(exclude=["attachment.content"])
         s = s.filter('term', current_version=True)
 
@@ -196,7 +196,7 @@ class ComponentSearch(FacetedSearch):
         search = search.highlight_options(
             number_of_fragments=0, pre_tags=pre_tags, post_tags=post_tags, require_field_match=True
         )
-        return super(ComponentSearch, self).highlight(search)
+        return super().highlight(search)
 
 
 def get_archive(id):
@@ -231,7 +231,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
 
     def __init__(self, *args, **kwargs):
         self.client = get_connection()
-        super(ComponentSearchViewSet, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_view_name(self):
         return u'Search {}'.format(getattr(self, 'suffix', None))
@@ -334,7 +334,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
         if pager == 'none':
             return None
 
-        return super(ComponentSearchViewSet, self).paginator
+        return super().paginator
 
     def list(self, request):
         params = {key: value[0] for (key, value) in dict(request.query_params).items()}


### PR DESCRIPTION
`super` in Python 3 requires no arguments, see [release notes](https://docs.python.org/3.0/whatsnew/3.0.html#builtins) and [PEP 3135](https://www.python.org/dev/peps/pep-3135/)