### PR TITLE
Show detail tab when selecting structure unit

### DIFF
--- a/ESSArch_PP/frontend/static/frontend/views/search.html
+++ b/ESSArch_PP/frontend/static/frontend/views/search.html
@@ -103,7 +103,7 @@
           <uib-tab ui-sref="home.access.search" index="0" heading="{{'ACCESS.HITS' | translate}}"> </uib-tab>
           <uib-tab
             ng-click="vm.goToDetailView()"
-            ng-show="latestRecord || ('home.access.search.detail' | isState) || ('home.access.search.information_package' | isState) || ('home.access.search.component' | isState)|| ('home.access.search.archive' | isState) || ('home.access.search.document' | isState) || ('home.access.search.directory' | isState)"
+            ng-show="latestRecord || ('home.access.search.detail' | isState) || ('home.access.search.information_package' | isState) || ('home.access.search.component' | isState)|| ('home.access.search.archive' | isState) || ('home.access.search.document' | isState) || ('home.access.search.directory' | isState) || ('home.access.search.structure_unit' | isState)"
             index="1"
             heading="{{'ACCESS.RECORD' | translate}}"
           >


### PR DESCRIPTION
Fixes bug where detail tab is not visible when selecting structure units