### PR TITLE
Replace detail/list_routes with action decorator

### DIFF
--- a/ESSArch_PP/profiles/views.py
+++ b/ESSArch_PP/profiles/views.py
@@ -30,7 +30,7 @@ import uuid
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from rest_framework import exceptions, serializers, status, viewsets
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -62,7 +62,7 @@ class SubmissionAgreementViewSet(SAViewSetCore):
 
         return super().update(request, *args, **kwargs)
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def publish(self, request, pk=None):
         if SubmissionAgreement.objects.values_list('published', flat=True).get(pk=pk):
             raise exceptions.ParseError('Submission agreement is already published')
@@ -71,7 +71,7 @@ class SubmissionAgreementViewSet(SAViewSetCore):
         SubmissionAgreement.objects.filter(pk=pk).update(published=True, template=template)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @detail_route(methods=['post'], url_path='include-type')
+    @action(detail=True, methods=['post'], url_path='include-type')
     def include_type(self, request, pk=None):
         sa = SubmissionAgreement.objects.get(pk=pk)
         ptype = request.data["type"]
@@ -83,7 +83,7 @@ class SubmissionAgreementViewSet(SAViewSetCore):
             'status': 'Including profile type %s in SA %s' % (ptype, sa)
         })
 
-    @detail_route(methods=['post'], url_path='exclude-type')
+    @action(detail=True, methods=['post'], url_path='exclude-type')
     def exclude_type(self, request, pk=None):
         sa = SubmissionAgreement.objects.get(pk=pk)
         ptype = request.data["type"]
@@ -95,7 +95,7 @@ class SubmissionAgreementViewSet(SAViewSetCore):
             'status': 'Excluding profile type %s in SA %s' % (ptype, sa)
         })
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def save(self, request, pk=None):
         if not request.user.has_perm('profiles.create_new_sa_generation'):
             raise exceptions.PermissionDenied
@@ -151,7 +151,7 @@ class ProfileSAViewSet(viewsets.ModelViewSet):
 
 
 class ProfileViewSet(ProfileViewSetCore):
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def save(self, request, pk=None):
         profile = Profile.objects.get(pk=pk)
         new_data = request.data.get("specification_data", {})
@@ -189,7 +189,7 @@ class ProfileMakerTemplateViewSet(viewsets.ModelViewSet):
     queryset = templatePackage.objects.all()
     serializer_class = ProfileMakerTemplateSerializer
 
-    @detail_route(methods=['post'], url_path='add-child')
+    @action(detail=True, methods=['post'], url_path='add-child')
     def add_child(self, request, pk=None):
         required = ['name', 'parent']
 
@@ -258,7 +258,7 @@ class ProfileMakerTemplateViewSet(viewsets.ModelViewSet):
         obj.save()
         return Response(existingElements, status=status.HTTP_201_CREATED)
 
-    @detail_route(methods=['delete'], url_path='delete-element')
+    @action(detail=True, methods=['delete'], url_path='delete-element')
     def delete_element(self, request, pk=None):
         required = ['uuid']
 
@@ -293,7 +293,7 @@ class ProfileMakerTemplateViewSet(viewsets.ModelViewSet):
         obj.save(update_fields=['existingElements'])
         return Response(obj.existingElements, status=status.HTTP_200_OK)
 
-    @detail_route(methods=['put'], url_path='update-element')
+    @action(detail=True, methods=['put'], url_path='update-element')
     def update_element(self, request, pk=None):
         required = ['uuid', 'data']
 
@@ -320,7 +320,7 @@ class ProfileMakerTemplateViewSet(viewsets.ModelViewSet):
         obj.save(update_fields=['existingElements'])
         return Response(obj.existingElements, status=status.HTTP_200_OK)
 
-    @detail_route(methods=['put'], url_path='update-contains-files')
+    @action(detail=True, methods=['put'], url_path='update-contains-files')
     def update_contains_files(self, request, pk=None):
         required = ['uuid', 'contains_files']
 
@@ -349,7 +349,7 @@ class ProfileMakerTemplateViewSet(viewsets.ModelViewSet):
         obj.save(update_fields=['existingElements'])
         return Response(obj.existingElements, status=status.HTTP_200_OK)
 
-    @detail_route(methods=['post'], url_path='add-attribute')
+    @action(detail=True, methods=['post'], url_path='add-attribute')
     def add_attribute(self, request, pk=None):
         required = ['uuid', 'data']
 
@@ -375,7 +375,7 @@ class ProfileMakerTemplateViewSet(viewsets.ModelViewSet):
         obj.save(update_fields=['existingElements'])
         return Response(obj.existingElements, status=status.HTTP_200_OK)
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def generate(self, request, pk=None):
         class SimpleProfileSerializer(serializers.ModelSerializer):
             class Meta:

--- a/ESSArch_PP/storage/views.py
+++ b/ESSArch_PP/storage/views.py
@@ -28,7 +28,7 @@ import uuid
 from django.contrib.auth.models import User
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, filters, permissions, status, viewsets
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
@@ -66,7 +66,7 @@ class IOQueueViewSet(viewsets.ModelViewSet):
 
         return IOQueueWriteSerializer
 
-    @list_route(methods=['post'], url_path='from-master')
+    @action(detail=False, methods=['post'], url_path='from-master')
     def from_master(self, request, pk=None):
         try:
             entry_data = request.data.pop('entry')
@@ -178,7 +178,7 @@ class IOQueueViewSet(viewsets.ModelViewSet):
 
         return Response(io_obj.id, status=status.HTTP_201_CREATED)
 
-    @detail_route(methods=['post'], url_path='add-file')
+    @action(detail=True, methods=['post'], url_path='add-file')
     def add_file(self, request, pk=None):
         entry = self.get_object()
 
@@ -207,7 +207,7 @@ class IOQueueViewSet(viewsets.ModelViewSet):
         upload_id = request.data.get('upload_id', uuid.uuid4().hex)
         return Response({'upload_id': upload_id})
 
-    @detail_route(methods=['post'], url_path='add-file_complete')
+    @action(detail=True, methods=['post'], url_path='add-file_complete')
     def add_file_complete(self, request, pk=None):
         entry = self.get_object()
 
@@ -232,7 +232,7 @@ class IOQueueViewSet(viewsets.ModelViewSet):
 
         return Response('Upload of %s complete' % filepath)
 
-    @detail_route(methods=['post'], url_path='all-files-done')
+    @action(detail=True, methods=['post'], url_path='all-files-done')
     def all_files_done(self, request, pk=None):
         entry = self.get_object()
         entry.status = 0
@@ -262,7 +262,7 @@ class StorageMediumViewSet(viewsets.ModelViewSet):
         'id', 'medium_id', 'status', 'location', 'location_status', 'used_capacity', 'create_date',
     )
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def mount(self, request, pk=None):
         medium = self.get_object()
 
@@ -280,7 +280,7 @@ class StorageMediumViewSet(viewsets.ModelViewSet):
 
         return Response(status=status.HTTP_202_ACCEPTED)
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def unmount(self, request, pk=None):
         medium = self.get_object()
 
@@ -359,7 +359,7 @@ class RobotViewSet(viewsets.ModelViewSet):
         'id', 'label', 'device', 'online',
     )
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def inventory(self, request, pk=None):
         robot = self.get_object()
 
@@ -421,7 +421,7 @@ class TapeDriveViewSet(viewsets.ModelViewSet):
         'id', 'device', 'num_of_mounts', 'idle_time',
     )
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def mount(self, request, pk=None):
         drive = self.get_object()
 
@@ -444,7 +444,7 @@ class TapeDriveViewSet(viewsets.ModelViewSet):
 
         return Response()
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def unmount(self, request, pk=None):
         drive = self.get_object()
         force = request.data.get('force', False)

--- a/ESSArch_PP/tags/search.py
+++ b/ESSArch_PP/tags/search.py
@@ -20,7 +20,7 @@ from elasticsearch.exceptions import NotFoundError, TransportError
 from elasticsearch_dsl import Q, FacetedSearch, TermsFacet
 from elasticsearch_dsl.connections import get_connection
 from rest_framework import exceptions, serializers, status
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -522,7 +522,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
         email.send()
         return Response(u'Email sent to {}'.format(user.email))
 
-    @detail_route(methods=['post'], url_path='send-as-email')
+    @action(detail=True, methods=['post'], url_path='send-as-email')
     def send_as_email(self, request, pk=None):
         tag = self.get_tag_object()
         user = self.request.user
@@ -548,7 +548,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
         email.send()
         return Response(u'Email sent to {}'.format(user.email))
 
-    @list_route(methods=['post'], url_path='mass-email')
+    @action(detail=False, methods=['post'], url_path='mass-email')
     def mass_email(self, request):
         try:
             ids = request.data['ids']
@@ -561,7 +561,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
 
         return self.send_mass_email(ids, user)
 
-    @detail_route(methods=['get'])
+    @action(detail=True, methods=['get'])
     def children(self, request, pk=None):
         parent = self.get_tag_object()
         structure = self.request.query_params.get('structure')
@@ -576,7 +576,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
 
         return Response(TagVersionNestedSerializer(children, many=True, context=context).data)
 
-    @detail_route(methods=['get'], url_path='child-by-value')
+    @action(detail=True, methods=['get'], url_path='child-by-value')
     def child_by_value(self, request, pk=None):
         class ByValueSerializer(serializers.Serializer):
             field = serializers.CharField(required=True)
@@ -606,13 +606,13 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
         except IndexError:
             raise exceptions.NotFound()
 
-    @detail_route(methods=['post'], url_path='new-version')
+    @action(detail=True, methods=['post'], url_path='new-version')
     def new_version(self, request, pk=None):
         tag = self.get_tag_object()
         tag.create_new()
         return Response()
 
-    @detail_route(methods=['post'], url_path='new-structure')
+    @action(detail=True, methods=['post'], url_path='new-structure')
     def new_structure(self, request, pk=None):
         try:
             name = request.data['name']
@@ -626,13 +626,13 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
 
         return Response()
 
-    @detail_route(methods=['patch'], url_path='set-as-current-version')
+    @action(detail=True, methods=['patch'], url_path='set-as-current-version')
     def set_as_current_version(self, request, pk=None):
         tag = self.get_tag_object()
         tag.set_as_current_version()
         return Response()
 
-    @detail_route(methods=['post'], url_path='change-organization')
+    @action(detail=True, methods=['post'], url_path='change-organization')
     def change_organization(self, request, pk=None):
         tag = self.get_tag_object(qs=TagVersion.objects.filter(elastic_index='archive'))
 
@@ -801,7 +801,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
         script = self._get_delete_field_script(field)
         self.client.update(index=index, doc_type='doc', id=tag.pk, body={"script": script})
 
-    @detail_route(methods=['post'], url_path='update-descendants')
+    @action(detail=True, methods=['post'], url_path='update-descendants')
     def update_descendants(self, request, pk=None):
         tag = self.get_tag_object()
         include_self = request.query_params.get('include_self', False)
@@ -815,7 +815,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
 
         return Response()
 
-    @list_route(methods=['post'], url_path='mass-update')
+    @action(detail=False, methods=['post'], url_path='mass-update')
     def mass_update(self, request):
         try:
             ids = request.query_params['ids'].split(',')
@@ -835,7 +835,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
 
         return Response()
 
-    @detail_route(methods=['post'], url_path='delete-field')
+    @action(detail=True, methods=['post'], url_path='delete-field')
     def delete_field(self, request, pk=None):
         tag = self.get_tag_object()
         try:
@@ -846,7 +846,7 @@ class ComponentSearchViewSet(ViewSet, PaginatedViewMixin):
         self._delete_field(tag, field)
         return Response(tag.from_search())
 
-    @detail_route(methods=['post'], url_path='remove-from-structure')
+    @action(detail=True, methods=['post'], url_path='remove-from-structure')
     def remove_from_structure(self, request, pk=None):
         obj = self.get_tag_object()
 

--- a/ESSArch_PP/tags/views.py
+++ b/ESSArch_PP/tags/views.py
@@ -2,7 +2,7 @@ from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from mptt.templatetags.mptt_tags import cache_tree_children
 from rest_framework import exceptions, viewsets
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.response import Response
@@ -28,7 +28,7 @@ class StructureViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     ordering_fields = ('name', 'create_date', 'version',)
     search_fields = ('name',)
 
-    @detail_route(methods=['get'])
+    @action(detail=True, methods=['get'])
     def tree(self, request, pk=None):
         obj = self.get_object()
 
@@ -63,7 +63,7 @@ class StructureUnitViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
             raise exceptions.ValidationError('Parent must be from the same classification structure')
         serializer.save(structure_id=structure)
 
-    @detail_route(methods=['get'])
+    @action(detail=True, methods=['get'])
     def nodes(self, request, pk=None, parent_lookup_structure=None):
         archive_id = request.query_params.get('archive')
         unit = self.get_object()
@@ -84,7 +84,7 @@ class StructureUnitViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
 
         return Response(TagVersionNestedSerializer(children, many=True, context=context).data)
 
-    @detail_route(methods=['get'])
+    @action(detail=True, methods=['get'])
     def children(self, request, pk=None, parent_lookup_structure=None):
         unit = self.get_object()
         if unit.is_leaf_node():


### PR DESCRIPTION
`detail_route` and `list_route` were deprecated and replaced by the `action` decorator in Django Rest Framework 3.8. Release notes: https://www.django-rest-framework.org/community/3.8-announcement/#action-decorator-replaces-list_route-and-detail_route