### PR TITLE
Fix Django deprecations

### DIFF
--- a/ESSArch_PP/config/settings.py
+++ b/ESSArch_PP/config/settings.py
@@ -167,7 +167,7 @@ ASGI_APPLICATION = 'ESSArch_Core.routing.application'
 
 SITE_ID = 1
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/ESSArch_PP/config/urls.py
+++ b/ESSArch_PP/config/urls.py
@@ -205,8 +205,8 @@ router.register(r'search', ComponentSearchViewSet, base_name='search')
 
 urlpatterns = [
     url(r'^', include('ESSArch_Core.frontend.urls'), name='home'),
-    url(r'^accounts/changepassword', auth_views.password_change, {'post_change_redirect': '/'}),
-    url(r'^accounts/login/$', auth_views.login),
+    url(r'^accounts/changepassword', auth_views.PasswordChangeView.as_view(), {'post_change_redirect': '/'}),
+    url(r'^accounts/login/$', auth_views.LoginView.as_view()),
     url(r'^admin/', admin.site.urls),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api/', include(router.urls)),


### PR DESCRIPTION
[Django 1.10](https://docs.djangoproject.com/en/1.11/releases/1.10/#new-style-middleware): the `MIDDLEWARE_CLASSES` setting has been replaced by `MIDDLEWARE`

[Django 1.11](https://docs.djangoproject.com/en/1.11/releases/1.11/#django-contrib-auth): `django.contrib.auth.views.password_change` and `django.contrib.auth.views.login` has been replaced by `django.contrib.auth.views.PasswordChangeView` and `django.contrib.auth.views.LoginView`