### PR TITLE
Fix formly form styling in profile editor and sa editor

### DIFF
--- a/ESSArch_PP/frontend/static/frontend/styles/modules/reception.scss
+++ b/ESSArch_PP/frontend/static/frontend/styles/modules/reception.scss
@@ -186,7 +186,9 @@ input[type='checkbox'] {
   }
 }
 
-.reception {
+.reception,
+.profile-editor .edit-form,
+.sa-editor .edit-view {
   .formly-field-group {
     width: 100% !important;
   }


### PR DESCRIPTION
Earlier css rule was too restrictive and caused forms in profile and sa editor to look unstructured