### PR TITLE
Fix deprecated urlpattern

### DIFF
--- a/ESSArch_PP/config/urls.py
+++ b/ESSArch_PP/config/urls.py
@@ -223,4 +223,4 @@ urlpatterns = [
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if getattr(settings, 'ENABLE_ADFS_LOGIN', False):
-    urlpatterns.append(url(r'^saml2/', include('djangosaml2.urls', namespace='saml2')))
+    urlpatterns.append(url(r'^saml2/', include('djangosaml2.urls')))


### PR DESCRIPTION
[Deprecated in Django 1.9](https://docs.djangoproject.com/en/2.2/releases/1.9/#passing-a-3-tuple-or-an-app-name-to-include)